### PR TITLE
Reset animation clock on initial playback

### DIFF
--- a/lib/ViewModels/AnimationViewModel.js
+++ b/lib/ViewModels/AnimationViewModel.js
@@ -38,6 +38,7 @@ var AnimationViewModel = function(options) {
 
     this.showAnimation = false;
     this.isPlaying = false;
+    this.initialPlay = true;
     this.isLooping = false;
     this.currentTimeString = '';
 
@@ -53,6 +54,7 @@ var AnimationViewModel = function(options) {
     this.terria.clock.onTick.addEventListener(function(clock) {
         var time = clock.currentTime;
         that.currentTimeString = formatDateTime(JulianDate.toDate(time), that.locale);
+		that.initialPlay = false;
     });
 
     knockout.getObservable(this.terria, 'showTimeline').subscribe(function(showTimeline) {
@@ -173,6 +175,10 @@ AnimationViewModel.prototype.gotoStart = function() {
 
 AnimationViewModel.prototype.togglePlay = function() {
     this.terria.analytics.logEvent('navigation', 'click', 'togglePlay');
+
+    if (this.isInitialPlay) {
+        this.terria.clock.currentTime = this.terria.clock.startTime;
+    }
 
     if (this.terria.clock.multiplier < 0) {
         this.terria.clock.multiplier = -this.terria.clock.multiplier;


### PR DESCRIPTION
When auto-play is disabled, the first animation frame defaults to
Date.now() - clock.creationTime, which jumps ahead as if autoplay were
enabled initially. To prevent this, we reset the initial timestamp at
the first animation playback